### PR TITLE
 update alpine version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine3.10
+FROM python:3.7-alpine3.11
 LABEL maintainer="The Peerchemist <peerchemist@protonmail.ch>"
 # based on work by lukechilds, https://github.com/lukechilds/docker-electrumx/
 


### PR DESCRIPTION
had build issue with 3.10:


`ERROR: unsatisfiable constraints:
  gflags-dev (missing):
    required by: rocksdb-dev-5.18.4-r0[gflags-dev]
The command '/bin/sh -c chmod a+x /usr/local/bin/* &&     apk add --no-cache build-base openssl &&     apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/community leveldb-dev &&     apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing rocksdb-dev &&     pip install aiohttp pylru plyvel websockets python-rocksdb &&     python setup.py install &&     rm -rf /var/cache/apk/* &&     apk del build-base &&     rm -rf /tmp/*' returned a non-zero code: 2`

works fine with 3.11